### PR TITLE
Remove spaceless from twig templates

### DIFF
--- a/src/Resources/views/Form/ewz_recaptcha_widget.html.twig
+++ b/src/Resources/views/Form/ewz_recaptcha_widget.html.twig
@@ -1,5 +1,4 @@
 {% block ewz_recaptcha_widget %}
-{% apply spaceless %}
   {% if form.vars.ewz_recaptcha_enabled %}
     {% if not form.vars.ewz_recaptcha_ajax %}
       {% if attr.options.size == 'invisible' and attr.options.callback is not defined %}
@@ -79,6 +78,5 @@
       </script>
     {% endif %}
   {% endif %}
-{% endapply %}
 {% endblock ewz_recaptcha_widget %}
 

--- a/src/Resources/views/Form/v3/ewz_recaptcha_widget.html.twig
+++ b/src/Resources/views/Form/v3/ewz_recaptcha_widget.html.twig
@@ -1,5 +1,4 @@
 {% block ewz_recaptcha_widget %}
-{% apply spaceless %}
   {% if form.vars.ewz_recaptcha_enabled %}
     <script src="{{ form.vars.ewz_recaptcha_api_uri }}?render={{ form.vars.public_key }}"></script>
 
@@ -25,5 +24,4 @@
       }, false);
     </script>
   {% endif %}
-{% endapply %}
 {% endblock %}


### PR DESCRIPTION
https://trello.com/c/asufn1Di/5469-update-to-twig-3-18-0-parte-4-usar-fork-de-excelwebzone-recaptcha-bundle-para-evitar-el-uso-de-spaceless